### PR TITLE
fix: 🐛 Add default to indentation parameter

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -41,8 +41,9 @@ AddCodeOfConduct:
 
 Indentation:
   type: int
-  help: Indentation for JuliaForm
+  help: Indentation length for many formatters and linters
   validator: "{% if Indentation <= 0 %}Indentation must be positive{% endif %}"
+  default: 2
 
 AddMacToCI:
   type: bool


### PR DESCRIPTION
Set default indentation to 2 and fix the description as well.

<!--
Thanks for making a pull request to this project.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #72

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] I am following the [contributing guidelines](../docs/src/contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](../CHANGELOG.md) was updated
