### PR TITLE
feat: 🎸 Add AskAdvancedQuestions to allow stopping early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning].
 - Indentation option (#44)
 - CODE_OF_CONDUCT (#25)
 - Issue and Pull Request templates (#33)
+- AskAdvancedQuestions question to allow stopping early (#67)
 
 ### Fixed
 

--- a/copier.yml
+++ b/copier.yml
@@ -33,30 +33,42 @@ License:
     - GPL-3.0
     - MIT
     - MPL-2.0
+  default: MIT
+
+AskAdvancedQuestions:
+  type: bool
+  help: Ask further questions? You can stop now with the minimum and use default values.
+  default: false
 
 AddCodeOfConduct:
+  when: "{{ AskAdvancedQuestions }}"
   type: bool
   default: true
   help: Add a CODE_OF_CONDUCT.md file from Contributor Covenant? {{ AuthorEmail }} will be listed as contact point.
 
 Indentation:
+  when: "{{ AskAdvancedQuestions }}"
   type: int
   help: Indentation for JuliaForm
   validator: "{% if Indentation <= 0 %}Indentation must be positive{% endif %}"
 
 AddMacToCI:
+  when: "{{ AskAdvancedQuestions }}"
   type: bool
   help: Add macos on CI?
 
 AddWinToCI:
+  when: "{{ AskAdvancedQuestions }}"
   type: bool
   help: Add windows on CI?
 
 RunJuliaNightlyOnCI:
+  when: "{{ AskAdvancedQuestions }}"
   type: bool
   help: Run the nightly version of Julia on CI?
 
 UseCirrusCI:
+  when: "{{ AskAdvancedQuestions }}"
   type: bool
   help: Create a .cirrusci.yml file?
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ template_options = Dict(
   "PackageOwner" => "test",
   "AuthorName" => "Test",
   "AuthorEmail" => "test@me.now",
+  "AskAdvancedQuestions" => true,
   "JuliaMinVersion" => "1.6",
   "License" => "MIT",
   "AddCodeOfConduct" => true,


### PR DESCRIPTION
AskAdvancedQuestions creates a separation between the basic questions
and the questions that are opinative or advanced. In the future, we can
create more fine-tuned defaults and let the user choose from them.

✅ Closes: #67
