### PR TITLE
fix: 🐛 Add continue-on-error to allow nightly to fail

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -29,6 +29,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:

--- a/template/.github/workflows/Test.yml.jinja
+++ b/template/.github/workflows/Test.yml.jinja
@@ -28,6 +28,7 @@ jobs:
   test:
     {% raw %}name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}{% endraw %}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
On Test.yml, add missing continue-on-error that interacts with
allow_failure in the matrix and decides whether the ubilds can fail or
not. This allows nightly builds to fail.

✅ Closes: #51
