### PR TITLE
fix: 🐛 Run tests correctly and fix bad raw enclosing

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -42,6 +42,9 @@ jobs:
         allow_failure: [false]
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -42,8 +42,6 @@ jobs:
         allow_failure: [false]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -42,6 +42,8 @@ jobs:
         allow_failure: [false]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -21,7 +21,7 @@ function generate(path, generate_missing_uuid = true; kwargs...)
   if generate_missing_uuid && !("PackageUUID" in keys(data))
     data["PackageUUID"] = string(uuid4())
   end
-  copier.run_copy("https://github.com/abelsiqueira/COPIERTemplate.jl", path; kwargs..., data = data)
+  copier.run_copy(joinpath(@__DIR__, ".."), path; kwargs..., data = data, vcs_ref = "HEAD")
 end
 
 end

--- a/template/.github/workflows/Test.yml.jinja
+++ b/template/.github/workflows/Test.yml.jinja
@@ -27,8 +27,8 @@ on:
 jobs:
   test:
     {% raw %}name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}{% endraw %}
-    continue-on-error: ${{ matrix.allow_failure }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}{% endraw %}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A previous commit included the key continue-on-error that should inside
the raw enclosure. Tests did not run because of #119.

✅ Closes: #120
