### PR TITLE
Print post-installation info

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -82,3 +82,18 @@ _skip_if_exists:
   - LICENSE
 
 _subdirectory: template
+
+_message_after_copy: |
+  Your project {{ PackageName }}.jl has been created successfully! 🎉
+
+  Next steps: Create git repository and push to Github.
+  $ cd {{ PackageName }}.jl
+  $ git init
+  $ git add .
+  $ pre-commit run -a # Try to fix possible pre-commit issues (failures are expected)
+  $ git add .
+  $ git commit -m "First commit"
+  $ pre-commit install # Future commits can't be directly to main unless you use -n
+  Create a repo on GitHub and push your code to it.
+
+  Read the full guide: https://abelsiqueira.com/COPIERTemplate.jl/stable/10-full-guide


### PR DESCRIPTION
<!--
Thanks for making a pull request to this project.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

Prints a message:

```bash
Your project YourPackage.jl has been created successfully! 🎉

Next steps: Create git repository and push to Github.
$ cd YourPackage.jl
$ git init
$ git add .
$ pre-commit run -a # Try to fix possible pre-commit issues (failures are expected)
$ git add .
$ git commit -m "First commit"
$ pre-commit install # Future commits can't be directly to main unless you use -n
Create a repo on GitHub and push your code to it.

Read the full guide: https://abelsiqueira.com/COPIERTemplate.jl/stable/10-full-guide
```
using [copier feature `message_after_copy`](https://copier.readthedocs.io/en/stable/configuring/#message_after_copy).

We consider that this message is printed after generating a **new package** with COPIERTemplate.jl. The message in the case where a user use COPIERTemplate.jl for modifying an existing package will need to be added later.

Question for maintainers: 
- Should we add this to the CHANGELOG.md?
- I used `$` for terminal commands, other options are `>`, I do not have a preference.
- I used emoji 🎉, not sure if is going to be supported in all terminals. Also this is the reason why I didn't try making the text more fancy with bold or other color styles.
- For the link, I also avoided formatting for compatibility with different terminals.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #152

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/CHANGELOG.md) was updated
