### PR TITLE
Allow optional src_path argument to generate that default to URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning].
 - More reader-friendly README (#144)
 - Add author names to licenses (#145)
 
+### Changed
+
+- Signature of generate now accepts source path, which defaults to the URL (#174)
+
 ## [0.3.1] - 2024-05-23
 
 ### Added

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -21,7 +21,7 @@ function generate(path, generate_missing_uuid = true; kwargs...)
   if generate_missing_uuid && !("PackageUUID" in keys(data))
     data["PackageUUID"] = string(uuid4())
   end
-  copier.run_copy(joinpath(@__DIR__, ".."), path; kwargs..., data = data, vcs_ref = "HEAD")
+  copier.run_copy("https://github.com/abelsiqueira/COPIERTemplate.jl", path; kwargs..., data = data, vcs_ref = "HEAD")
 end
 
 end

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -7,21 +7,29 @@ function __init__()
 end
 
 """
-    generate(path, generate_missing_uuid = true; kwargs...)
+    generate(dst_path, generate_missing_uuid = true; kwargs...)
+    generate(src_path, dst_path, generate_missing_uuid = true; kwargs...)
 
 Runs the `copy` command of [copier](https://github.com/copier-org/copier) with the COPIERTemplate template.
+
+If `src_path` is not informed, the GitHub URL of COPIERTemplate.jl is used.
+
 Even though the template is available offline through this template, this uses the github URL to allow updating.
 
 The keyword arguments are passed directly to the `run_copy` function of `copier`.
 If `generate_missing_uuid` is `true` and there is no `kwargs[:data]["PackageUUID"]`, then a UUID is generated for the package.
 """
-function generate(path, generate_missing_uuid = true; kwargs...)
+function generate(src_path, dst_path, generate_missing_uuid = true; kwargs...)
   copier = PythonCall.pyimport("copier")
   data = copy(get(kwargs, :data, Dict()))
   if generate_missing_uuid && !("PackageUUID" in keys(data))
     data["PackageUUID"] = string(uuid4())
   end
-  copier.run_copy("https://github.com/abelsiqueira/COPIERTemplate.jl", path; kwargs..., data = data, vcs_ref = "HEAD")
+  copier.run_copy(src_path, dst_path; kwargs..., data = data, vcs_ref = "HEAD")
+end
+
+function generate(dst_path, args...; kwargs...)
+  generate("https://github.com/abelsiqueira/COPIERTemplate.jl", dst_path, args...; kwargs...)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,18 @@ end
 
 bash_args = vcat([["-d"; "$k=$v"] for (k, v) in template_options]...)
 template_path = joinpath(@__DIR__, "..")
+template_url = "https://github.com/abelsiqueira/COPIERTemplate.jl"
+
+@testset "Compare COPIERTemplate.generate vs copier CLI on URL/main" begin
+  mktempdir(; prefix = "cli_") do dir_copier_cli
+    run(`copier copy --vcs-ref main --quiet $bash_args $template_url $dir_copier_cli`)
+
+    mktempdir(; prefix = "copy_") do tmpdir
+      COPIERTemplate.generate(tmpdir; data = template_options, quiet = true, vcs_ref = "main")
+      test_diff_dir(tmpdir, dir_copier_cli)
+    end
+  end
+end
 
 @testset "Compare COPIERTemplate.generate vs copier CLI on HEAD" begin
   # This is a hack because Windows managed to dirty the repo.
@@ -62,7 +74,13 @@ template_path = joinpath(@__DIR__, "..")
     run(`copier copy --vcs-ref HEAD --quiet $bash_args $template_path $dir_copier_cli`)
 
     mktempdir(; prefix = "copy_") do tmpdir
-      COPIERTemplate.generate(tmpdir; data = template_options, quiet = true, vcs_ref = "HEAD")
+      COPIERTemplate.generate(
+        template_path,
+        tmpdir;
+        data = template_options,
+        quiet = true,
+        vcs_ref = "HEAD",
+      )
       test_diff_dir(tmpdir, dir_copier_cli)
     end
   end


### PR DESCRIPTION
Instead of using the copier.yml from ~/.julia/** use GH url.

TODO
* [x] make url an argument
* [x] use same branch/repo for template as where generate() function is defined, To make sure in a PR that changes both generator and template are tested together. 

<!--
Thanks for making a pull request to this project.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

Fixes #146
<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/CHANGELOG.md) was updated
