### PR TITLE
docs: ✏️ Change orgremote to upstream and clarify instructions

### DIFF
--- a/docs/src/90-developer.md
+++ b/docs/src/90-developer.md
@@ -33,6 +33,9 @@ pre-commit run -a
 
 ## First time clone
 
+!!! note "If you have writing rights"
+    If you have writing rights, you don't have to fork. Instead, simply clone and skip ahead. Whenever **upstream** is mentioned, use **origin** instead.
+
 If this is the first time you work with this repository, follow the instructions below to clone the repository.
 
 1. Fork this repo
@@ -40,17 +43,20 @@ If this is the first time you work with this repository, follow the instructions
 3. Add this repo as a remote:
 
    ```bash
-   git remote add orgremote https://github.com/abelsiqueira/COPIERTemplate.jl
+   git remote add upstream https://github.com/abelsiqueira/COPIERTemplate.jl
    ```
+
+This will ensure that you have two remotes in your git: `origin` and `upstream`.
+You will create branches and push to `origin`, and you will fetch and update your local `main` branch from `upstream`.
 
 ## Working on a new issue
 
-1. Fetch from the JSO remote and fast-forward your local main
+1. Fetch from the remote and fast-forward your local main
 
    ```bash
-   git fetch orgremote
+   git fetch upstream
    git switch main
-   git merge --ff-only orgremote/main
+   git merge --ff-only upstream/main
    ```
 
 2. Branch from `main` to address the issue (see below for naming)
@@ -88,8 +94,8 @@ If this is the first time you work with this repository, follow the instructions
 - Fetch any `main` updates from upstream and rebase your branch, if necessary:
 
    ```bash
-   git fetch orgremote
-   git rebase orgremote/main BRANCH_NAME
+   git fetch upstream
+   git rebase upstream/main BRANCH_NAME
    ```
 
 - Then you can open a pull request and work with the reviewer to address any issues.

--- a/template/docs/src/90-developer.md.jinja
+++ b/template/docs/src/90-developer.md.jinja
@@ -33,6 +33,9 @@ pre-commit run -a
 
 ## First time clone
 
+!!! note "If you have writing rights"
+    If you have writing rights, you don't have to fork. Instead, simply clone and skip ahead. Whenever **upstream** is mentioned, use **origin** instead.
+
 If this is the first time you work with this repository, follow the instructions below to clone the repository.
 
 1. Fork this repo
@@ -40,17 +43,20 @@ If this is the first time you work with this repository, follow the instructions
 3. Add this repo as a remote:
 
    ```bash
-   git remote add orgremote https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl
+   git remote add upstream https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl
    ```
+
+This will ensure that you have two remotes in your git: `origin` and `upstream`.
+You will create branches and push to `origin`, and you will fetch and update your local `main` branch from `upstream`.
 
 ## Working on a new issue
 
-1. Fetch from the JSO remote and fast-forward your local main
+1. Fetch from the remote and fast-forward your local main
 
    ```bash
-   git fetch orgremote
+   git fetch upstream
    git switch main
-   git merge --ff-only orgremote/main
+   git merge --ff-only upstream/main
    ```
 
 2. Branch from `main` to address the issue (see below for naming)
@@ -88,8 +94,8 @@ If this is the first time you work with this repository, follow the instructions
 - Fetch any `main` updates from upstream and rebase your branch, if necessary:
 
    ```bash
-   git fetch orgremote
-   git rebase orgremote/main BRANCH_NAME
+   git fetch upstream
+   git rebase upstream/main BRANCH_NAME
    ```
 
 - Then you can open a pull request and work with the reviewer to address any issues.


### PR DESCRIPTION
Instead of using orgremote for the organization git, use upstream.
Explain what to do if you have writing rights and don't need to fork.
Explain why we have two remotes.

✅ Closes: #165
