### PR TITLE
feat: 🎸 Only run ubuntu with Julia 1 on PRs

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -1,0 +1,47 @@
+name: Reusable test
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        default: "1"
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+      arch:
+        required: false
+        type: string
+        default: x64
+      allow_failure:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test:
+    name: Julia ${{ inputs.version }} - ${{ inputs.os }} - ${{ inputs.arch }} - ${{ github.event_name }}
+    runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.allow_failure }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ inputs.version }}
+          arch: ${{ inputs.arch }}
+      - name: Use Julia cache
+        uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          file: lcov.info

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -41,6 +41,15 @@ jobs:
         arch:
           - x64
         allow_failure: [false]
+        is-pr:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          - is-pr: true
+        include:
+          - version: "1"
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -5,29 +5,16 @@ on:
     branches:
       - main
     tags: ["*"]
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "src/**"
-      - "test/**"
-      - "template/**"
-      - "*.toml"
-      - "copier.yml"
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
-
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: ${{ matrix.os }}
+      version: ${{ matrix.version }}
+      arch: ${{ matrix.arch }}
+      allow_failure: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,31 +28,3 @@ jobs:
         arch:
           - x64
         allow_failure: [false]
-        is-pr:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          - is-pr: true
-        include:
-          - version: "1"
-            os: ubuntu-latest
-            arch: x64
-            allow_failure: false
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - name: Use Julia cache
-        uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
-        with:
-          file: lcov.info

--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -1,0 +1,26 @@
+name: Test Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+      - "*.toml"
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test:
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: ubuntu-latest
+      version: "1"
+      arch: x64
+      allow_failure: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
-- New question: TestPRsOnlyOneMachine to simplify the testing on Pull Requests (#105)
+- New question: SimplifiedPRTest to simplify the testing on Pull Requests (#105)
 
 ## [0.4.0] - 2024-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- New question: TestPRsOnlyOneMachine to simplify the testing on Pull Requests (#105)
+
 ## [0.4.0] - 2024-05-31
 
 ### Added

--- a/copier.yml
+++ b/copier.yml
@@ -72,7 +72,7 @@ RunJuliaNightlyOnCI:
 SimplifiedPRTest:
   when: "{{ AskAdvancedQuestions }}"
   type: bool
-  help: (Simplified PR Test) Do you want to limit the Pull Request test to a single configuration (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might introduce OS-specific or LTS specific errors.
+  help: (Simplified PR Test) Do you want to limit the Pull Request test to a single configuration (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might miss OS-specific or LTS specific errors.
   default: true
 
 UseCirrusCI:

--- a/copier.yml
+++ b/copier.yml
@@ -69,6 +69,12 @@ RunJuliaNightlyOnCI:
   type: bool
   help: Package tests run on Julia version {{ JuliaMinVersion }} and on the latest stable release. Do you also want to run them on the nightly version?
 
+TestPRsOnlyOneMachine:
+  when: "{{ AskAdvancedQuestions }}"
+  type: bool
+  help: Do you want to limit the PR test to a single machine (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might introduce OS-specific or LTS specific errors.
+  default: true
+
 UseCirrusCI:
   when: "{{ AskAdvancedQuestions }}"
   type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -69,10 +69,10 @@ RunJuliaNightlyOnCI:
   type: bool
   help: Package tests run on Julia version {{ JuliaMinVersion }} and on the latest stable release. Do you also want to run them on the nightly version?
 
-TestPRsOnlyOneMachine:
+SimplifiedPRTest:
   when: "{{ AskAdvancedQuestions }}"
   type: bool
-  help: Do you want to limit the PR test to a single machine (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might introduce OS-specific or LTS specific errors.
+  help: (Simplified PR Test) Do you want to limit the Pull Request test to a single configuration (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might introduce OS-specific or LTS specific errors.
   default: true
 
 UseCirrusCI:

--- a/docs/src/20-explanation.md
+++ b/docs/src/20-explanation.md
@@ -120,7 +120,10 @@ We have a few workflows, with plans to expand in the future:
 - Docs.yml: Build the docs. Only runs when relevant files change.
 - Lint.yml: Run the linter and formatter through the command `pre-commit run -a`.
 - TagBot.yml: Create GitHub releases automatically after your new release is merged on the Registry.
-- Test.yml: Run the tests.
+- For testing, we have
+  - ReusableTest.yml: Defines a reusable workflow with the testing.
+  - Test.yml: Defines a matrix of tests to be run whenever `main` is updated or a tag is created. Uses the ReusableTest workflow. If "Simplified PR Test" was not chosen, then this also runs when there are pull requests.
+  - TestOnPRs.yml: Defines a test to be run when pull requests are created. Only the latest stable Julia version is tested on a ubuntu-latest image. Uses the ReusableTest workflow. If "Simplified PR Test" was not chosen, then this file does not exist.
 
 ### Issues and PR templates
 

--- a/template/.github/workflows/ReusableTest.yml
+++ b/template/.github/workflows/ReusableTest.yml
@@ -1,0 +1,42 @@
+name: Reusable test
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        default: "1"
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+      arch:
+        required: false
+        type: string
+        default: x64
+      allow_failure:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test:
+    name: Julia ${{ inputs.version }} - ${{ inputs.os }} - ${{ inputs.arch }} - ${{ github.event_name }}
+    runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.allow_failure }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ inputs.version }}
+          arch: ${{ inputs.arch }}
+      - name: Use Julia cache
+        uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          file: lcov.info

--- a/template/.github/workflows/Test.yml.jinja
+++ b/template/.github/workflows/Test.yml.jinja
@@ -4,31 +4,25 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "src/**"
-      - "test/**"
-      - "*.toml"
     tags: ["*"]
-  pull_request:
+  {% if not SimplifiedPRTest %}pull_request:
     branches:
       - main
     paths:
       - "src/**"
       - "test/**"
       - "*.toml"
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]{% endif %}
+  workflow_dispatch:
 
-{% raw %}concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-{% endraw %}
 jobs:
   test:
-    {% raw %}name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}{% endraw %}
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: {% raw %}${{ matrix.os }}{% endraw %}
+      version: {% raw %}${{ matrix.version }}{% endraw %}
+      arch: {% raw %}${{ matrix.arch }}{% endraw %}
+      allow_failure: {% raw %}${{ matrix.allow_failure }}{% endraw %}
     strategy:
       fail-fast: false
       matrix:
@@ -42,46 +36,17 @@ jobs:
         arch:
           - x64
         allow_failure: [false]
-        is-pr:
-          - {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
-        {% if RunJuliaNightlyOnCI or TestPRsOnlyOneMachine %}include:{% endif %}
         {% if RunJuliaNightlyOnCI %}
+        include:
           - version: "nightly"
             os: ubuntu-latest
             arch: x64
             allow_failure: true
-            is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
-          {% if not AddMacToCI %}#{% endif %}- version: "nightly"
-          {% if not AddMacToCI %}#{% endif %}  os: macOS-latest
-          {% if not AddMacToCI %}#{% endif %}  arch: x64
-          {% if not AddMacToCI %}#{% endif %}  allow_failure: true
-          {% if not AddMacToCI %}#{% endif %}  is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
-          {% if not AddWinToCI %}#{% endif %}- version: "nightly"
-          {% if not AddWinToCI %}#{% endif %}  os: windows-latest
-          {% if not AddWinToCI %}#{% endif %}  arch: x64
-          {% if not AddWinToCI %}#{% endif %}  allow_failure: true
-          {% if not AddWinToCI %}#{% endif %}  is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
-        {% endif %}{% if TestPRsOnlyOneMachine %}
-          - version: "1"
-            os: ubuntu-latest
+          {% if AddMacToCI %}- version: "nightly"
+            os: macOS-latest
             arch: x64
-            allow_failure: false
-            is-pr: false
-        exclude:
-          - is-pr: true
-        {% endif %}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        {% raw %}with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-        {% endraw %}
-      - name: Use Julia cache
-        uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
-        with:
-          file: lcov.info
+            allow_failure: true{% endif %}
+          {% if AddWinToCI %}- version: "nightly"
+            os: windows-latest
+            arch: x64
+            allow_failure: true{% endif %}{% endif %}

--- a/template/.github/workflows/Test.yml.jinja
+++ b/template/.github/workflows/Test.yml.jinja
@@ -42,19 +42,34 @@ jobs:
         arch:
           - x64
         allow_failure: [false]
-        {% if RunJuliaNightlyOnCI %}include:
+        is-pr:
+          - {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
+        {% if RunJuliaNightlyOnCI or TestPRsOnlyOneMachine %}include:{% endif %}
+        {% if RunJuliaNightlyOnCI %}
           - version: "nightly"
             os: ubuntu-latest
             arch: x64
             allow_failure: true
+            is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
           {% if not AddMacToCI %}#{% endif %}- version: "nightly"
           {% if not AddMacToCI %}#{% endif %}  os: macOS-latest
           {% if not AddMacToCI %}#{% endif %}  arch: x64
           {% if not AddMacToCI %}#{% endif %}  allow_failure: true
+          {% if not AddMacToCI %}#{% endif %}  is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
           {% if not AddWinToCI %}#{% endif %}- version: "nightly"
           {% if not AddWinToCI %}#{% endif %}  os: windows-latest
           {% if not AddWinToCI %}#{% endif %}  arch: x64
-          {% if not AddWinToCI %}#{% endif %}  allow_failure: true{% endif %}
+          {% if not AddWinToCI %}#{% endif %}  allow_failure: true
+          {% if not AddWinToCI %}#{% endif %}  is-pr: {% raw %}${{ github.event_name == 'pull_request' }}{% endraw %}
+        {% endif %}{% if TestPRsOnlyOneMachine %}
+          - version: "1"
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: false
+            is-pr: false
+        exclude:
+          - is-pr: true
+        {% endif %}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/template/.github/workflows/{% if SimplifiedPRTest %}TestOnPRs.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if SimplifiedPRTest %}TestOnPRs.yml{% endif %}.jinja
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+      - "*.toml"
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: {% raw %}${{ startsWith(github.ref, 'refs/pull/') }}{% endraw %}
+
+jobs:
+  test:
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: ubuntu-latest
+      version: "1"
+      arch: x64
+      allow_failure: false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ template_options = Dict(
   "AddMacToCI" => true,
   "AddWinToCI" => true,
   "RunJuliaNightlyOnCI" => true,
-  "TestPRsOnlyOneMachine" => true,
+  "SimplifiedPRTest" => true,
   "UseCirrusCI" => true,
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ template_options = Dict(
   "AddMacToCI" => true,
   "AddWinToCI" => true,
   "RunJuliaNightlyOnCI" => true,
+  "TestPRsOnlyOneMachine" => true,
   "UseCirrusCI" => true,
 )
 


### PR DESCRIPTION
Using the workflow matrix and conditions to include and exclude, we only
run the full matrix on pushes. For PRs, only 1 build is made, using
ubuntu and Julia 1.

Also adds a question TestPRsOnlyOneMachine to include the same in the template. Defaults to true.

✅ Closes: #105
