### PR TITLE
refactor: 💡 Remove generate_missing_uuid argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning].
 - New question: SimplifiedPRTest to simplify the testing on Pull Requests (#105)
 - New question: AddAllcontributors to add a section and config for <https://allcontributors.org> (#26)
 
+### Removed
+
+- The `generate_missing_uuid` argument was removed, since it can be generated via Jinja (#189)
+
 ## [0.4.0] - 2024-05-31
 
 ### Added

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -7,8 +7,8 @@ function __init__()
 end
 
 """
-    generate(dst_path, generate_missing_uuid = true; kwargs...)
-    generate(src_path, dst_path, generate_missing_uuid = true; kwargs...)
+    generate(dst_path; kwargs...)
+    generate(src_path, dst_path; kwargs...)
 
 Runs the `copy` command of [copier](https://github.com/copier-org/copier) with the COPIERTemplate template.
 
@@ -17,15 +17,10 @@ If `src_path` is not informed, the GitHub URL of COPIERTemplate.jl is used.
 Even though the template is available offline through this template, this uses the github URL to allow updating.
 
 The keyword arguments are passed directly to the `run_copy` function of `copier`.
-If `generate_missing_uuid` is `true` and there is no `kwargs[:data]["PackageUUID"]`, then a UUID is generated for the package.
 """
-function generate(src_path, dst_path, generate_missing_uuid = true; kwargs...)
+function generate(src_path, dst_path; kwargs...)
   copier = PythonCall.pyimport("copier")
-  data = copy(get(kwargs, :data, Dict()))
-  if generate_missing_uuid && !("PackageUUID" in keys(data))
-    data["PackageUUID"] = string(uuid4())
-  end
-  copier.run_copy(src_path, dst_path; kwargs..., data = data, vcs_ref = "HEAD")
+  copier.run_copy(src_path, dst_path; kwargs..., vcs_ref = "HEAD")
 end
 
 function generate(dst_path, args...; kwargs...)


### PR DESCRIPTION
The generate_missing_uuid argument is not necessary anymore since Jinja
generates one for us.

BREAKING CHANGE: 🧨 The API of generate has been changed.

✅ Closes: #189
