### PR TITLE
Fix tests on windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,7 @@ function test_diff_dir(dir1, dir2)
     for (root, _, files) in walkdir(dir1)
       nice_dir(file) =
         replace(root, dir1 => "") |> out -> replace(out, r"^/" => "") |> out -> joinpath(out, file)
-      if nice_dir("") |> startswith(".git")
+      if nice_dir("") |> x -> occursin(r"[\\/]?git[\\/]+", x)
         continue
       end
       @testset "File $(nice_dir(file))" for file in files


### PR DESCRIPTION
Make the folder difference in the test more robust by usign regex to check for \.git\ or /.git/ or .git/. This also makes sure that the .github folder is not skipped.

<!--
Thanks for making a pull request to this project.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes nothing.

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/COPIERTemplate.jl/blob/main/CHANGELOG.md) was updated
