### PR TITLE
feat: 🎸 Read from dst_path/Project.toml to guess answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning].
 - New question: SimplifiedPRTest to simplify the testing on Pull Requests (#105)
 - New question: AddAllcontributors to add a section and config for <https://allcontributors.org> (#26)
 - `copy`, `recopy` and `update` from the copier API (#142)
+- When applying to existing projects, read Project.toml to infer a few values (#116)
 
 ### Changed
 

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.0"
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -10,6 +10,8 @@ module COPIERTemplate
 
 include("Copier.jl")
 
+using TOML: TOML
+
 """
     generate(dst_path[, data]; kwargs...)
     generate(src_path, dst_path[, data]; true, kwargs...)
@@ -24,11 +26,50 @@ The `data` argument is a dictionary of answers (values) to questions (keys) that
 The keyword arguments are passed directly to the internal [`Copier.copy`](@ref).
 """
 function generate(src_path, dst_path, data::Dict = Dict(); kwargs...)
+  # If there are answers in the destionation path, skip guessing the answers
+  if !isfile(joinpath(dst_path, ".copier-answers")) && isdir(dst_path)
+    existing_data = _read_data_from_existing_path(dst_path)
+    for (key, value) in existing_data
+      @info "Inferred $key=$value from destination path"
+      if haskey(data, key)
+        @info "  Being overriden by supplied $key=$(data[key]) value"
+      end
+    end
+    data = merge(existing_data, data)
+  end
   Copier.copy(src_path, dst_path, data; kwargs...)
 end
 
 function generate(dst_path, data::Dict = Dict(); kwargs...)
   generate("https://github.com/abelsiqueira/COPIERTemplate.jl", dst_path, data; kwargs...)
+end
+
+"""
+    data = _read_data_from_existing_path(dst_path)
+
+Reads the destination folder to figure out some answers.
+"""
+function _read_data_from_existing_path(dst_path)
+  data = Dict{String, Any}()
+  if isfile(joinpath(dst_path, "Project.toml"))
+    toml_data = TOML.parsefile(joinpath(dst_path, "Project.toml"))
+    for (toml_key, copier_key) in [("name", "PackageName"), ("uuid", "PackageUUID")]
+      if haskey(toml_data, toml_key)
+        data[copier_key] = toml_data[toml_key]
+      end
+    end
+    # Author capture is limited and does not handle multiple authors. See #118 for more information.
+    if haskey(toml_data, "authors")
+      author_regex = r"^(.*) <(.*)>(?: and contributors)?"
+      m = match(author_regex, toml_data["authors"][1])
+      if !isnothing(m)
+        data["AuthorName"] = m[1]
+        data["AuthorEmail"] = m[2]
+      end
+    end
+  end
+
+  return data
 end
 
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,4 @@
 [deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"


### PR DESCRIPTION
If dsp_path/Project.toml exists, read from it to guess some of the
answers. Passing data to the generate function will override the guessed
values.

BREAKING CHANGE: 🧨 Applying to existing packages has a different behaviour now.

✅ Closes: #116
