### PR TITLE
feat: 🎸 Determine package name from the dst_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning].
 - New question: AddAllcontributors to add a section and config for <https://allcontributors.org> (#26)
 - `copy`, `recopy` and `update` from the copier API (#142)
 - When applying to existing projects, read Project.toml to infer a few values (#116)
+- Automatically determines the `PackageName` from the destination folder (#151)
 
 ### Changed
 

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -37,6 +37,14 @@ function generate(src_path, dst_path, data::Dict = Dict(); kwargs...)
     end
     data = merge(existing_data, data)
   end
+  # If the PackageName was not given or guessed from the Project.toml, use the sanitized path
+  if !haskey(data, "PackageName")
+    package_name = _sanitize_package_name(dst_path)
+    if package_name != ""
+      @info "Using sanitized path $package_name as package name"
+      data["PackageName"] = package_name
+    end
+  end
   Copier.copy(src_path, dst_path, data; kwargs...)
 end
 
@@ -70,6 +78,18 @@ function _read_data_from_existing_path(dst_path)
   end
 
   return data
+end
+
+"""
+    package_name = _sanitize_package_name(path)
+
+Sanitize the `path` to guess the package_name by looking at the
+base name and removing an extension. If the result is not a valid
+identifier, returns "".
+"""
+function _sanitize_package_name(dst_path)
+  package_name = dst_path |> basename |> splitext |> first
+  return Base.isidentifier(package_name) ? package_name : ""
 end
 
 end


### PR DESCRIPTION
If possible, determine the package name from the destination path.

BREAKING CHANGE: 🧨 PackageName is now automatically defined, instead of asked.

✅ Closes: #151
