### PR TITLE
fix: 🐛 Cannot use double quotes in interpolation in GHA

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ matrix.version }}
       arch: ${{ matrix.arch }}
       allow_failure: ${{ matrix.allow_failure }}
-      run_codecov: ${{ matrix.version == "1" && matrix.os == "ubuntu-latest" }}
+      run_codecov: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     strategy:


### PR DESCRIPTION
In the ${{ ... }} commands, only single quotes are allowed.
