### PR TITLE
feat: 🎸 Use lychee instead of markdown-link-checker

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -41,3 +41,14 @@ jobs:
         run: pip install pre-commit
       - name: Run pre-commit
         run: SKIP=no-commit-to-branch pre-commit run -a
+  link-checker:
+    name: Link checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          fail: true

--- a/.markdown-link-config.json
+++ b/.markdown-link-config.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "@ref"
-    }
-  ]
-}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,9 +47,3 @@ repos:
     rev: v1.0.56
     hooks:
       - id: julia-formatter
-  - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.12.2
-    hooks:
-      - id: markdown-link-check
-        args:
-          - --config=.markdown-link-config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,6 @@ and this project adheres to [Semantic Versioning].
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 <!-- Versions -->
-<!-- markdown-link-check-disable -->
 
 [unreleased]: https://github.com/abelsiqueira/COPIERTemplate.jl/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/abelsiqueira/COPIERTemplate.jl/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ If you would like to get involved in the COPIERTemplate growth, please check our
 If your interest is in developing the package, check the [development guide](docs/src/90-developer.md) as well.
 
 ### Contributors
-<!-- markdown-link-check-disable -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ end
 makedocs(;
   modules = [COPIERTemplate],
   doctest = true,
-  linkcheck = true,
+  linkcheck = false,
   authors = "Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors",
   repo = "https://github.com/abelsiqueira/COPIERTemplate.jl/blob/{commit}{path}#{line}",
   sitename = "COPIERTemplate.jl",

--- a/docs/src/20-explanation.md
+++ b/docs/src/20-explanation.md
@@ -107,7 +107,7 @@ Installing pre-commit (`pre-commit install`) will make sure that it runs the rel
 Furthermore, if you run `pre-commit run -a`, it runs all hooks.
 
 Some hooks in the `.pre-commit-config.yaml` file have configuration files of their own:
-`.JuliaFormatter.toml`, `.markdownlint.json`, `.markdown-link-config.json`, and `.yamllint.yml`.
+`.JuliaFormatter.toml`, `.markdownlint.json`, `lychee.toml`, and `.yamllint.yml`.
 
 Also slightly related, is the `.editorconfig` file, which tells your editor, if you install the correct plugin, how to format some things.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,7 +40,6 @@ If your interest is in developing the package, check the [development guide](90-
 ## Contributors
 
 ```@raw html
-<!-- markdown-link-check-disable -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,9 @@
+exclude = [
+  "@ref",
+  "^https://github.com/.*/releases/tag/v.*$"
+]
+
+exclude_path = [
+  "docs/build",
+  "test/conda-env"
+]

--- a/template/.github/workflows/Lint.yml
+++ b/template/.github/workflows/Lint.yml
@@ -41,3 +41,14 @@ jobs:
         run: pip install pre-commit
       - name: Run pre-commit
         run: SKIP=no-commit-to-branch pre-commit run -a
+  link-checker:
+    name: Link checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          fail: true

--- a/template/.markdown-link-config.json
+++ b/template/.markdown-link-config.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "@ref"
-    }
-  ]
-}

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -47,9 +47,3 @@ repos:
     rev: v1.0.56
     hooks:
       - id: julia-formatter
-  - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.12.2
-    hooks:
-      - id: markdown-link-check
-        args:
-          - --config=.markdown-link-config.json

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,7 +1,6 @@
 # {{ PackageName }}
 
 <!-- This check was disabled because these links don't exist until you push, create documentation, and create your first release -->
-<!-- markdown-link-check-disable -->
 [![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/stable)
 [![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/dev)
 [![Build Status](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/workflows/Test/badge.svg)](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/actions)
@@ -23,8 +22,6 @@ If you use {{ PackageName }}.jl in your work, please cite using the reference gi
 If you want to make contributions of any kind, please first that a look into our [contributing guide directly on GitHub](docs/src/90-contributing.md) or the [contributing page on the website](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/dev/contributing/).
 
 {% if AddAllcontributors %}### Contributors
-
-<!-- markdown-link-check-disable -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/template/docs/make.jl.jinja
+++ b/template/docs/make.jl.jinja
@@ -16,7 +16,7 @@ end
 makedocs(;
   modules = [{{ PackageName }}],
   doctest = true,
-  linkcheck = true,
+  linkcheck = false, # Rely on Lint.yml/lychee for the links
   authors = "{{ AuthorName }} <{{ AuthorEmail }}> and contributors",
   repo = "https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/{commit}{path}#{line}",
   sitename = "{{ PackageName }}.jl",

--- a/template/docs/src/index.md.jinja
+++ b/template/docs/src/index.md.jinja
@@ -8,8 +8,6 @@ Documentation for [{{ PackageName }}](https://github.com/{{ PackageOwner }}/{{ P
 
 {% if AddAllcontributors %}## Contributors
 
-<!-- markdown-link-check-disable -->
-
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/template/lychee.toml.jinja
+++ b/template/lychee.toml.jinja
@@ -1,0 +1,11 @@
+exclude = [
+  "@ref",
+  "^https://github.com/.*/releases/tag/v.*$",
+  "^https://doi.org/FIXME$",
+  "^https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/stable$",
+  "zenodo.org/badge/DOI/FIXME$"
+]
+
+exclude_path = [
+  "docs/build"
+]


### PR DESCRIPTION
Instead of running a pre-commit hook for the link-checker, run lychee on
the Lint.yml workflow. Also set the docs linkcheck to false.

✅ Closes: #160
