### PR TITLE
feat: 🎸 Add AnswerStrategy to allow minimum additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- New question: AddPrecommit to add pre-commit related files (#231)
+- New question: AddGitHubTemplates to add issue and PR templates (#233)
+- New question: AnswerStrategy to choose between using recommended, minimum, or ask every question (#235)
+
+### Changed
+
+- Issue checklists are now just text (#234)
+
 ## [0.5.0]
 
 ### Added

--- a/copier.yml
+++ b/copier.yml
@@ -38,20 +38,24 @@ License:
   default: MIT
 
 # Optional
-AskAdvancedQuestions:
-  type: bool
-  help: Ask further questions? You can stop now with the minimum and use the default values for code of conduct, indentation, and package tests.
-  default: false
+AnswerStrategy:
+  type: str
+  default: recommended
+  help: How do you want to deal with the optional questions? (You can use our defaults, or the bare minimum, or decide everything)
+  choices:
+    Recommended (Our defaults): "recommended"
+    Minimum (Answer no to any addition): "minimum"
+    Ask me (Ask all questions): "ask"
 
 # Formatting and Linting
 AddPrecommit:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
-  default: true
+  default: "{{ AnswerStrategy != 'minimum' }}"
   help: Add pre-commit config? (pre-commit runs before every commit fixing your formatting and preventing bad practices)
 
 Indentation:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: int
   help: Indentation length for many formatters and linters
   validator: "{% if Indentation <= 0 %}Indentation must be positive{% endif %}"
@@ -59,48 +63,52 @@ Indentation:
 
 # CI
 SimplifiedPRTest:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
   help: (Simplified PR Test) Do you want to limit the Pull Request test to a single configuration (ubuntu + latest stable Julia)? This will make the PR tests run faster, but might miss OS-specific or LTS specific errors.
-  default: true
+  default: "{{ AnswerStrategy != 'minimum' }}"
 
 AddMacToCI:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
   help: Package tests run on Ubuntu latest. Do you want to add macOS latest as well?
+  default: "{{ AnswerStrategy != 'minimum' }}"
 
 AddWinToCI:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
   help: Do you want to add Windows latest as well?
+  default: "{{ AnswerStrategy != 'minimum' }}"
 
 RunJuliaNightlyOnCI:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
   help: Package tests run on Julia version {{ JuliaMinVersion }} and on the latest stable release. Do you also want to run them on the nightly version?
+  default: false
 
 UseCirrusCI:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
   help: Add CirrusCI to run the package tests on FreeBSD?
+  default: false
 
 # General
 AddAllcontributors:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
-  default: true
+  default: "{{ AnswerStrategy != 'minimum' }}"
   help: Add allcontributors to the package?
 
 AddCodeOfConduct:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
-  default: true
+  default: "{{ AnswerStrategy != 'minimum' }}"
   help: Add a CODE_OF_CONDUCT.md file from Contributor Covenant? {{ AuthorEmail }} will be listed as contact point.
 
 AddGitHubTemplates:
-  when: "{{ AskAdvancedQuestions }}"
+  when: "{{ AnswerStrategy == 'ask' }}"
   type: bool
-  default: true
+  default: "{{ AnswerStrategy != 'minimum' }}"
   help: Add GitHub issue and PR templates? (These create forms for issue creation and information on Pull Requests to improve the description quality.)
 
 _skip_if_exists:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ template_options = Dict(
   "UseCirrusCI" => true,
   "AddPrecommit" => true,
   "AddGitHubTemplates" => true,
+  "AnswerStrategy" => "ask",
 )
 
 function test_diff_dir(dir1, dir2)


### PR DESCRIPTION
If AnswerStrategy is recommended, then we use our default. If it is
minimum, then we answer no to everything. Otherwise, we ask as usual.

✅ Closes: #235
