### PR TITLE
Create update wrapper and add update info to guide

### DIFF
--- a/docs/src/10-full-guide.md
+++ b/docs/src/10-full-guide.md
@@ -129,7 +129,36 @@ Now, go to [Setting up your package](@ref) to check what you still need to confi
 
 ### [Updating](@id updating_package)
 
-WIP. Tracked in issue #113.
+To update the package, simply call
+
+```julia-repl
+julia> COPIERTemplate.update()
+```
+
+You will be asked the relevant questions of the package as if you had applied it.
+The big differences are:
+
+- It will only apply the things that are new since you last applied/updated
+- It will remember previous answer.
+
+!!! tip "Change previous answers"
+    You can change your previous answers. In other words, if you though something was not mature enough in the past, but you are more confident in that now, you can adopt it now.
+
+As with the first application, you need to run `pre-commit run -a` to fix the unavoidable linting and formatting issues.
+Check the modifications in the relevant linter and formatting files, if you changed them manually, before doing it, though.
+
+```bash
+pre-commit run -a
+```
+
+The underlying package `copier` will use `git` to apply the differences and it will overwrite whatever files it finds in the way.
+Since `git` is mandatory, the changes will be left for you to review.
+
+!!! warning "Review the changes"
+    I repeat, the changes will be left for you to review.
+    Don't just add them blindly, because some of your modifications can and will be overwritten.
+
+If you need some help with undoing some of these changes, I recommend using a graphical interface.
 
 ## Setting up your package
 

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -53,6 +53,26 @@ function generate(dst_path, data::Dict = Dict(); kwargs...)
 end
 
 """
+    update([data]; kwargs...)
+    update(dst_path[, data]; kwargs...)
+
+Run the update command of copier, updating the `dst_path` (or the current path if omitted) with a new version of the template with a new version of the template.
+
+The `data` argument is a dictionary of answers (values) to questions (keys) that can be used to bypass some of the interactive questions.
+
+## Keyword arguments
+
+The keyword arguments are passed directly to the internal [`Copier.update`](@ref).
+"""
+function update(dst_path, data::Dict = Dict(); kwargs...)
+  Copier.update(dst_path, data; overwrite = true, kwargs...)
+end
+
+function update(data::Dict = Dict(); kwargs...)
+  update(".", data; overwrite = true, kwargs...)
+end
+
+"""
     data = _read_data_from_existing_path(dst_path)
 
 Reads the destination folder to figure out some answers.

--- a/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/10-bug-report.yml.jinja
+++ b/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/10-bug-report.yml.jinja
@@ -8,11 +8,11 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        Please, before submitting make sure that:
+        Please, before submitting, make sure that:
 
         - There is not an [existing issue](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/issues) with the same question
         - You have read the [contributing guide](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/docs/src/90-contributing.md/)
-        - You follow the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
 
         The form below should help you in filling out this issue.
   - type: textarea

--- a/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/20-feature-request.yml.jinja
+++ b/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/20-feature-request.yml.jinja
@@ -6,11 +6,11 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        Please, before submitting make sure that:
+        Please, before submitting, make sure that:
 
         - There is not an [existing issue](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/issues) with the same question
         - You have read the [contributing guide](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/docs/src/90-contributing.md/)
-        - You follow the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
 
         The form below should help you in filling out this issue.
   - type: textarea

--- a/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/30-usage.yml.jinja
+++ b/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/30-usage.yml.jinja
@@ -7,12 +7,12 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        Please, before submitting make sure that:
+        Please, before submitting, make sure that:
 
         - You have checked the [documentation](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl) and haven't found enough information
         - There is not an [existing issue](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/issues) with the same question
         - You have read the [contributing guide](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/docs/src/90-contributing.md/)
-        - You follow the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
 
         The form below should help you in filling out this issue.
   - type: textarea

--- a/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/99-general.yml.jinja
+++ b/template/.github/{% if AddGitHubTemplates %}ISSUE_TEMPLATE{% endif %}/99-general.yml.jinja
@@ -6,11 +6,11 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        Please, before submitting make sure that:
+        Please, before submitting, make sure that:
 
         - There is not an [existing issue](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/issues) with the same question
         - You have read the [contributing guide](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/docs/src/90-contributing.md/)
-        - You follow the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You are following the [code of conduct](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/main/CODE_OF_CONDUCT.md)
 
         The form below should help you in filling out this issue.
   - type: textarea

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,6 +1,5 @@
 # {{ PackageName }}
 
-<!-- This check was disabled because these links don't exist until you push, create documentation, and create your first release -->
 [![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/stable)
 [![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/dev)
 [![Build Status](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/workflows/Test/badge.svg)](https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/actions)
@@ -11,7 +10,7 @@
 [![Coverage](https://codecov.io/gh/{{ PackageOwner }}/{{ PackageName }}.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/{{ PackageOwner }}/{{ PackageName }}.jl)
 [![DOI](https://zenodo.org/badge/DOI/FIXME)](https://doi.org/FIXME)
 {% if AddCodeOfConduct %}[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md){% endif %}
-{% if AddAllcontributors %}[![All Contributors](https://img.shields.io/github/all-contributors/{{ PackageOwner }}/{{ PackageName }}.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square))](.all-contributorsrc){% endif %}
+{% if AddAllcontributors %}[![All Contributors](https://img.shields.io/github/all-contributors/{{ PackageOwner }}/{{ PackageName }}.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square))](#contributors){% endif %}
 
 ## How to Cite
 

--- a/template/docs/src/90-contributing.md.jinja
+++ b/template/docs/src/90-contributing.md.jinja
@@ -1,10 +1,10 @@
-# Contributing guidelines
+# [Contributing guidelines](@id contributing)
 
 First of all, thanks for the interest!
 
 We welcome all kinds of contribution, including, but not limited to code, documentation, examples, configuration, issue creating, etc.
 
-Be polite and respectful.
+Be polite and respectful, and follow the code of conduct.
 
 ## Bug reports and discussions
 

--- a/template/docs/src/90-reference.md.jinja
+++ b/template/docs/src/90-reference.md.jinja
@@ -1,4 +1,4 @@
-# Reference
+# [Reference](@id reference)
 
 ## Contents
 

--- a/template/docs/src/index.md.jinja
+++ b/template/docs/src/index.md.jinja
@@ -8,6 +8,7 @@ Documentation for [{{ PackageName }}](https://github.com/{{ PackageOwner }}/{{ P
 
 {% if AddAllcontributors %}## Contributors
 
+```@raw
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
@@ -16,4 +17,5 @@ Documentation for [{{ PackageName }}](https://github.com/{{ PackageOwner }}/{{ P
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+```
 {% endif %}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,34 @@ end
   end
 end
 
+@testset "Compare COPIERTemplate.update vs copier CLI update" begin
+  mktempdir(TMPDIR; prefix = "cli_") do dir_copier_cli
+    run(`copier copy --defaults --quiet $min_bash_args $template_url $dir_copier_cli`)
+    cd(dir_copier_cli) do
+      run(`git init`)
+      run(`git add .`)
+      run(`git config user.name "Test"`)
+      run(`git config user.email "test@test.com"`)
+      run(`git commit -q -m "First commit"`)
+    end
+    run(`copier update --defaults --quiet $bash_args $dir_copier_cli`)
+
+    mktempdir(TMPDIR; prefix = "update_") do tmpdir
+      COPIERTemplate.generate(tmpdir, template_minimum_options; defaults = true, quiet = true)
+      cd(tmpdir) do
+        run(`git init`)
+        run(`git add .`)
+        run(`git config user.name "Test"`)
+        run(`git config user.email "test@test.com"`)
+        run(`git commit -q -m "First commit"`)
+        COPIERTemplate.update(template_options; defaults = true, quiet = true)
+      end
+
+      test_diff_dir(tmpdir, dir_copier_cli)
+    end
+  end
+end
+
 @testset "Testing copy, recopy and rebase" begin
   mktempdir(TMPDIR; prefix = "cli_") do dir_copier_cli
     run(`copier copy --quiet $bash_args $template_path $dir_copier_cli`)


### PR DESCRIPTION
Create a update wrapper calling the internal Copier update. The
overwrite=true argument needs to be passed to mimic the CLI behaviour.
Updates the guide with specific information to update.

✅ Closes: https://github.com/abelsiqueira/COPIERTemplate.jl/issues/113